### PR TITLE
Style news item page

### DIFF
--- a/templates/custom/news-item.html
+++ b/templates/custom/news-item.html
@@ -1,0 +1,89 @@
+{% load static %}
+{% load component_tags %}
+
+<article>
+  <header>
+    <div class="container mx-auto max-w-screen-xl relative">
+      {% include 'custom/edit-on-github.html' with rel_path='custom/news-item.html' %}
+      <div class="relative z-0 top-0 max-md:-right-36 md:-right-12">
+        <img
+          class="
+            motion-safe:rallax absolute z-0 w-12 max-lg:top-0 lg:top-0
+            max-lg:right-52 lg:right-96
+          "
+          src="{% static 'hourglass/media/backgrounds/circle-red.svg' %}"
+          alt="">
+        <img
+          class="
+            absolute max-lg:z-20 lg:z-0 max-lg:top-8 lg:top-16
+            max-lg:right-0 lg:right-20
+          "
+          src="{% static 'hourglass/media/backgrounds/circle-blue-textured.png' %}"
+          width="434"
+          alt="">
+        <img
+          class="motion-safe:rallax z-10 absolute top-56 -right-8 w-48"
+          src="{% static 'hourglass/media/backgrounds/square-red.svg' %}"
+          alt="">
+        <img
+          class="motion-safe:rallax absolute max-lg:hidden z-20 top-96 right-16 h-36"
+          src="{% static 'hourglass/media/backgrounds/triangle-orange-pointing-down.svg' %}"
+          alt="">
+      </div>
+      <div class="relative z-40">
+        <div class="prose lg:prose-lg pt-64 max-md:pr-8 md:px-8">
+          <h1 class="font-poppins-bold !leading-snug">
+            {{ news_item.title }}
+          </h1>
+          <p>
+            {% if news_item.byline %}
+              {{ news_item.byline }} {% trans "on" %}
+            {% endif %}
+            {{ news_item.posted|date:"j F Y" }}
+          </p>
+        </div>
+      </div>
+    </div>
+    <div class="container mx-auto max-w-screen-xl relative max-lg:mt-8 lg:mt-12">
+      <div class="lg:m-8 relative z-40">
+        <div class="
+          bg-tan-light md:max-w-[750px] md:max-h-[324px]
+          flex place-content-center
+        ">
+          <img
+            class="grayscale"
+            src="{{ news_item.best_image_url }}">
+        </div>
+        <div class="pt-4">
+          {% if news_item.tags.all %}
+            {% include "custom/news-item-tags.html" with tags=news_item.tags.all %}
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </header>
+  <main>
+    <div class="container mx-auto max-w-screen-xl relative max-lg:mt-8 lg:mt-12">
+      <div class="z-20 relative left-0 top-12">
+        <img
+          class="
+            motion-safe:rallax absolute z-20 w-12 top-64
+            max-lg:-left-6 lg:left-12
+          "
+          src="{% static 'hourglass/media/backgrounds/rectangle-red.svg' %}"
+          alt="">
+        <img
+          class="absolute z-10 w-96 -left-20 top-48"
+          src="{% static 'hourglass/media/backgrounds/circle-blue-textured.png' %}"
+          width="434"
+          alt="">
+      </div>
+      {% component_block "page_section" anchor="right" %}
+        {{ news_item.body|safe }}
+      {% endcomponent_block %}
+    </div>
+  </main>
+</article>
+<div class="container mx-auto max-w-screen-xl relative">
+  {% include 'custom/subscribe.html' %}
+</div>

--- a/templates/press/news/item.html
+++ b/templates/press/news/item.html
@@ -27,27 +27,5 @@
 {% endblock meta_image %}
 
 {% block body %}
-  <article>
-    <header class="row max800">
-      <h1>{{ news_item.title }}</h1>
-      <p class="byline">
-        {{ news_item.byline }} {% trans "on" %} {{ news_item.posted|date:"j F Y" }}
-      </p>
-      <img class="responsive-img" src="{{ news_item.best_image_url }}">
-    </header>
-    <main class="row max640">
-      {{ news_item.body|safe }}
-    </main>
-    {% if news_item.tags.all %}
-      <footer class="row max640" aria-label="tags">
-        {% for item_tag in news_item.tags.all %}
-          <a href="{% url 'core_news_list_tag' item_tag.text %}">
-            <span class="chip black-text">
-              {{ item_tag.text }}
-            </span>
-          </a>
-        {% endfor %}
-      </footer>
-    {% endif %}
-  </article>
+  {% include "custom/news-item.html" %}
 {% endblock body %}


### PR DESCRIPTION
Closes #76.

For this one we wanted a few baseline things that are achieved in this PR:

- Sensible geometric shape lockups that could work for anything (without black-and-white photos)
- A way to display proper full news item images if provided
- A way to display logos and less-than-ideal images (with a background so they don't clash with shapes)
- A fallback image

We also thought it might be possible to use full lockups with photos when the news item didn't provide. This is trickier than we imagined because of variable headline lengths and mobile screen accessibility. So I've set that goal aside for now.

![news-item-proper-image](https://github.com/BirkbeckCTP/hourglass/assets/47217308/e32405f1-c4c8-4192-93f5-797475b5aeb3)
![news-item-proper-image-lg](https://github.com/BirkbeckCTP/hourglass/assets/47217308/8b533002-d529-48d7-8fd4-809dc1c30d7e)
![news-item-logo-image](https://github.com/BirkbeckCTP/hourglass/assets/47217308/5e1863fb-dc74-41ec-942a-2c8ba5eba56c)
![news-item-logo-image-lg](https://github.com/BirkbeckCTP/hourglass/assets/47217308/2cc5cc3d-a95a-4ac8-bdf5-d0da2821b20f)
