### PR TITLE
Update DOI example on oa-glossary.html

### DIFF
--- a/templates/custom/oa-glossary.html
+++ b/templates/custom/oa-glossary.html
@@ -1,4 +1,4 @@
-{% extends "press/cms/page.html" %}
+ {% extends "press/cms/page.html" %}
 
 {% load static %}
 {% load component_tags %}
@@ -58,7 +58,7 @@
               </div>
               <div>
                 <dt class="term">Document Object Identifier (DOI)</dt>
-                <dd class="description">an identifier in the form 10.7766/orbit.v2.1.50 or http://dx.doi.org/10.7766/orbit.v2.1.50 that uniquely addresses a scholarly resource. The DOI system is part of the digital preservation infrastructure as, in the event that a journal goes offline or the publisher folds, the DOI is updated to point to the preserved version, ensuring continued access. A DOI is supposed to be an identifier that will always return the resource and it comes with substantial social structures (such as financial penalties if metadata are not kept up-to date) to ensure this.</dd>
+                <dd class="description">an identifier in the form 10.7766/orbit.v2.1.50 or https://doi.org/10.7766/orbit.v2.1.50 that uniquely addresses a scholarly resource. The DOI system is part of the digital preservation infrastructure as, in the event that a journal goes offline or the publisher folds, the DOI is updated to point to the preserved version, ensuring continued access. A DOI is supposed to be an identifier that will always return the resource and it comes with substantial social structures (such as financial penalties if metadata are not kept up-to date) to ensure this.</dd>
               </div>
               <div>
                 <dt class="term">Double dipping</dt>


### PR DESCRIPTION
The dx.doi.org urls have long been deprecated