### PR TITLE
Add comma to articles published

### DIFF
--- a/templates/custom/counter-block.html
+++ b/templates/custom/counter-block.html
@@ -1,3 +1,5 @@
+{% load humanize %}
+
 <section
   aria-label="OLH in numbers"
   class="
@@ -28,7 +30,7 @@
           Articles published
         </p>
         <p class="font-poppins-bold max-lg:text-6xl lg:text-8xl">
-          {{ request.press.published_articles.count }}
+          {{ request.press.published_articles.count|intcomma }}
         </p>
       </div>
       <div class="flex flex-col max-lg:items-center">


### PR DESCRIPTION
Closes #262.
Closes #287.

@S-Haime you had the solution! Just also needed to load up `humanize` which allows `intcomma` to be used.