### PR TITLE
Add imports of TinyMCE

### DIFF
--- a/templates/core/base.html
+++ b/templates/core/base.html
@@ -63,6 +63,12 @@
       <!-- JavaScript dependencies -->
       <script src="{% static 'hourglass/js/simple-scrollspy.min.js' %}"></script>
       <script src="{% static 'hourglass/js/rallax.js' %}"></script>
+      {% if settings.DEBUG %}
+        <script src="{% static "common/js/tinymce/tinymce.js" %}"></script>
+      {% else %}
+        <script src="{% static "common/js/tinymce/tinymce.min.js" %}"></script>
+      {% endif %}
+      <script src="{% static "django_tinymce/init_tinymce.js" %}"></script>
 
       <!-- custom JavaScript -->
       <script>


### PR DESCRIPTION
Closes #345.
Closes #346.

I opted not to try to add in-editor styling. I looked into applying the Tailwind Typography plugin, which is what we use to style user-entered text and most of the prose on the site, but could not get it working in the time we have.